### PR TITLE
cd: fix parsing relative positions to absolute path

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1074,59 +1074,57 @@ class bulkrename(Command):
 
         # Create and edit the file list
         filenames = [f.relative_path for f in self.fm.thistab.get_selection()]
-        listfile = tempfile.NamedTemporaryFile(delete=False)
-        listpath = listfile.name
-
-        if py3:
-            listfile.write("\n".join(filenames).encode(encoding="utf-8",
-                                                       errors="surrogatepass"))
-        else:
-            listfile.write("\n".join(filenames))
-        listfile.close()
+        with tempfile.NamedTemporaryFile(delete=False) as listfile:
+            listpath = listfile.name
+            if py3:
+                listfile.write("\n".join(filenames).encode(
+                    encoding="utf-8", errors="surrogatepass"))
+            else:
+                listfile.write("\n".join(filenames))
         self.fm.execute_file([File(listpath)], app='editor')
-        listfile = open(listpath, 'r')
-        new_filenames = listfile.read().split("\n")
-        listfile.close()
+        with (open(listpath, 'r', encoding="utf-8", errors="surrogatepass") if
+              py3 else open(listpath, 'r')) as listfile:
+            new_filenames = listfile.readlines()
         os.unlink(listpath)
         if all(a == b for a, b in zip(filenames, new_filenames)):
             self.fm.notify("No renaming to be done!")
             return
 
         # Generate script
-        cmdfile = tempfile.NamedTemporaryFile()
-        script_lines = []
-        script_lines.append("# This file will be executed when you close the"
-                            " editor.")
-        script_lines.append("# Please double-check everything, clear the file"
-                            " to abort.")
-        new_dirs = []
-        for old, new in zip(filenames, new_filenames):
-            if old != new:
-                basepath, _ = os.path.split(new)
-                if (basepath is not None and basepath not in new_dirs
-                        and not os.path.isdir(basepath)):
-                    script_lines.append("mkdir -vp -- {dir}".format(
-                        dir=esc(basepath)))
-                    new_dirs.append(basepath)
-                script_lines.append("mv -vi -- {old} {new}".format(
-                    old=esc(old), new=esc(new)))
-        # Make sure not to forget the ending newline
-        script_content = "\n".join(script_lines) + "\n"
-        if py3:
-            cmdfile.write(script_content.encode("utf-8"))
-        else:
-            cmdfile.write(script_content)
-        cmdfile.flush()
+        with tempfile.NamedTemporaryFile() as cmdfile:
+            script_lines = []
+            script_lines.append("# This file will be executed when you close"
+                                " the editor.")
+            script_lines.append("# Please double-check everything, clear the"
+                                " file to abort.")
+            new_dirs = []
+            for old, new in zip(filenames, new_filenames):
+                if old != new:
+                    basepath, _ = os.path.split(new)
+                    if (basepath is not None and basepath not in new_dirs
+                            and not os.path.isdir(basepath)):
+                        script_lines.append("mkdir -vp -- {dir}".format(
+                            dir=esc(basepath)))
+                        new_dirs.append(basepath)
+                    script_lines.append("mv -vi -- {old} {new}".format(
+                        old=esc(old), new=esc(new)))
+            # Make sure not to forget the ending newline
+            script_content = "\n".join(script_lines) + "\n"
+            if py3:
+                cmdfile.write(script_content.encode(encoding="utf-8",
+                                                    errors="surrogatepass"))
+            else:
+                cmdfile.write(script_content)
+            cmdfile.flush()
 
-        # Open the script and let the user review it, then check if the script
-        # was modified by the user
-        self.fm.execute_file([File(cmdfile.name)], app='editor')
-        cmdfile.seek(0)
-        script_was_edited = (script_content != cmdfile.read())
+            # Open the script and let the user review it, then check if the
+            # script was modified by the user
+            self.fm.execute_file([File(cmdfile.name)], app='editor')
+            cmdfile.seek(0)
+            script_was_edited = (script_content != cmdfile.read())
 
-        # Do the renaming
-        self.fm.run(['/bin/sh', cmdfile.name], flags='w')
-        cmdfile.close()
+            # Do the renaming
+            self.fm.run(['/bin/sh', cmdfile.name], flags='w')
 
         # Retag the files, but only if the script wasn't changed during review,
         # because only then we know which are the source and destination files.

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1078,7 +1078,8 @@ class bulkrename(Command):
         listpath = listfile.name
 
         if py3:
-            listfile.write("\n".join(filenames).encode("utf-8"))
+            listfile.write("\n".join(filenames).encode(encoding="utf-8",
+                                                       errors="surrogatepass"))
         else:
             listfile.write("\n".join(filenames))
         listfile.close()

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -169,7 +169,7 @@ class cd(Command):
                 dest_exp = tail
         else:
             dest_exp = ''
-        return (start, dest_exp, os.path.join(self.fm.thisdir.path, dest_exp),
+        return (start, dest_exp, os.path.abspath(os.path.join(self.fm.thisdir.path, dest_exp)),
                 dest.endswith(os.path.sep))
 
     @staticmethod

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1084,7 +1084,7 @@ class bulkrename(Command):
         self.fm.execute_file([File(listpath)], app='editor')
         with (open(listpath, 'r', encoding="utf-8", errors="surrogateescape") if
               py3 else open(listpath, 'r')) as listfile:
-            new_filenames = listfile.readlines()
+            new_filenames = listfile.read().split("\n")
         os.unlink(listpath)
         if all(a == b for a, b in zip(filenames, new_filenames)):
             self.fm.notify("No renaming to be done!")

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1078,11 +1078,11 @@ class bulkrename(Command):
             listpath = listfile.name
             if py3:
                 listfile.write("\n".join(filenames).encode(
-                    encoding="utf-8", errors="surrogatepass"))
+                    encoding="utf-8", errors="surrogateescape"))
             else:
                 listfile.write("\n".join(filenames))
         self.fm.execute_file([File(listpath)], app='editor')
-        with (open(listpath, 'r', encoding="utf-8", errors="surrogatepass") if
+        with (open(listpath, 'r', encoding="utf-8", errors="surrogateescape") if
               py3 else open(listpath, 'r')) as listfile:
             new_filenames = listfile.readlines()
         os.unlink(listpath)
@@ -1112,7 +1112,7 @@ class bulkrename(Command):
             script_content = "\n".join(script_lines) + "\n"
             if py3:
                 cmdfile.write(script_content.encode(encoding="utf-8",
-                                                    errors="surrogatepass"))
+                                                    errors="surrogateescape"))
             else:
                 cmdfile.write(script_content)
             cmdfile.flush()

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -275,7 +275,7 @@ class cd(Command):
             return None
         if len(paths) == 1:
             return start + paths[0] + sep
-        return [start + dirname for dirname in paths]
+        return [start + dirname + sep for dirname in paths]
 
 
 class chain(Command):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -169,7 +169,7 @@ class cd(Command):
                 dest_exp = tail
         else:
             dest_exp = ''
-        return (start, dest_exp, os.path.abspath(os.path.join(self.fm.thisdir.path, dest_exp)),
+        return (start, dest_exp, os.path.normpath(os.path.join(self.fm.thisdir.path, dest_exp)),
                 dest.endswith(os.path.sep))
 
     @staticmethod

--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -23,7 +23,7 @@ audio/ogg               oga ogg spx opus
 audio/wavpack           wv wvc
 audio/webm              weba
 audio/x-ape             ape
-audio/x-dsdiff          dsf
+audio/x-dsdiff          dsf dff
 audio/x-flac            flac
 
 image/vnd.djvu          djvu

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -95,8 +95,9 @@ handle_extension() {
             python -m json.tool -- "${FILE_PATH}" && exit 5
             ;;
 
-        ## Direct Stream Digital/Transfer (DSDIFF)
-        dsf)
+        ## Direct Stream Digital/Transfer (DSDIFF) and wavpack aren't detected
+        ## by file(1).
+        dff|dsf|wv|wvc)
             mediainfo "${FILE_PATH}" && exit 5
             exiftool "${FILE_PATH}" && exit 5
             ;; # Continue with next handler on failure


### PR DESCRIPTION
#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This pull request implements parsing the absolute path constructed from `self.fm.thisdir.path` and `dest_exp` in `_tab_args()` using `os.path.abspath()`. 
This is necessary because otherwise, if the user types relative navigation tokens in `cd`, like `../myDir` or `./myDir`, tab completion will not work, contrary to the usual shell's tab completion.